### PR TITLE
Fix typo, make command-line invokable

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -19,47 +19,47 @@ util.inherits(Storage, EventEmitter);
 
 
 Storage.prototype.initialize = function() {
-	
+
 	console.log('Storage: Initialize Storage...');
-	
+
 	this.initializeRedis();
-	
+
 	this.getBasicDetails();
 };
 
 Storage.prototype.initializeRedis = function() {
-	
+
 	this.client = redis.createClient();
-	
+
 	this.client.on('error', function(err) {
-		consol.log('Storage: Redis Error ' + err);
+		console.log('Storage: Redis Error ' + err);
 	});
-	
+
 	this.client.on('connect', function() {
 		console.log('Storage: Redis Client Connected...');
 	});
-	
+
 	this.client.on('end', function() {
 		console.log('Storage: Redis Connection Ended...');
-		
+
 		this.initializeRedis();
 	}.bind(this));
 };
 
 Storage.prototype.saveClick = function(clickId, click, callback) {
-	
+
 	this.client.set(constants.REDIS_CLICKS_KEY, clickId);
 	this.client.set(constants.REDIS_CLICK_KEY + clickId, JSON.stringify(click));
-	
+
 	if (callback) {
 		callback();
 	}
 };
 
 Storage.prototype.setLowestSecond = function(second, payload, callback) {
-	
+
 	this.client.hmset(constants.REDIS_SECONDS_KEY, second, JSON.stringify(payload));
-	
+
 	if (callback) {
 		callback();
 	}
@@ -70,7 +70,7 @@ Storage.prototype.getSeconds = function(callback) {
 	this.client.hgetall(constants.REDIS_SECONDS_KEY, function(err, obj) {
 		var lowest = 60;
 		var seconds = {};
-		
+
 		if (obj) {
 			for(var i in obj) {
 				seconds[i] = JSON.parse(obj[i]);
@@ -80,7 +80,7 @@ Storage.prototype.getSeconds = function(callback) {
 				}
 			}
 		}
-		
+
 		if (callback) {
 			callback(lowest, seconds);
 		}
@@ -88,7 +88,7 @@ Storage.prototype.getSeconds = function(callback) {
 };
 
 Storage.prototype.getClicks = function(callback) {
-	
+
 	this.client.get(constants.REDIS_CLICKS_KEY, function(err, reply) {
 		if (callback) {
 			callback(reply || 0);
@@ -100,35 +100,35 @@ Storage.prototype.getBasicDetails = function() {
 
 	this.getSeconds(function (lowest, seconds) {
 		this.getClicks(function(clicks) {
-			
+
 			var payload = {
 				lowest: lowest,
 				seconds: seconds,
 				clicks: clicks
 			};
-		
+
 			this.emit('loaded', payload);
 		}.bind(this));
 	}.bind(this));
 };
 
 Storage.prototype.loadClicks = function(callback) {
-	
+
 	this.client.get(constants.REDIS_CLICKS_KEY, function(err, reply) {
 		var callbacks = reply || 0;
-		
+
 		var done = function() {
 			callbacks--;
-			
-			if (callbacks == 0) {			
+
+			if (callbacks == 0) {
 				callback();
 			}
 		};
-		
+
 		if (callbacks == 0) {
 			callback();
 		}
-		
+
 		for (var i = 1; i<= reply; i++) {
 			this.loadClick(constants.REDIS_CLICK_KEY + i, (i == 1 ? 'first' : (i == reply ? 'last' : 'next')), done);
 		}
@@ -138,9 +138,9 @@ Storage.prototype.loadClicks = function(callback) {
 Storage.prototype.loadClick = function(key, type, callback) {
 	this.client.get(key, function(err, reply) {
 		var data = JSON.parse(reply);
-		
+
 		this.emit('clickData', data, type);
-		
+
 		callback();
 	}.bind(this));
 };

--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var Manager = require('./lib/manager');
 
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Console Monitoring for The Mighty Button (from Reddit)",
   "author": "CaBz",
   "main": "main.js",
+  "bin": {
+    "button": "main.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/CaBz/the-button"


### PR DESCRIPTION
There was a typo, `consol.log`.

Also made it invokable from the command line so that anyone who installs it globally with npm, can just run the command `button`.

Apologies for the whitespace changes, my editor removes excess whitespace from the end of lines. Use this URL to see just the logical changes:

https://github.com/CaBz/the-button/pull/1/files?w=1